### PR TITLE
Add fullRoute search option to Milepost

### DIFF
--- a/WSUT.Upgrade.Soe/Commands/FindRouteMilepostCommand.cs
+++ b/WSUT.Upgrade.Soe/Commands/FindRouteMilepostCommand.cs
@@ -15,7 +15,20 @@ namespace Wsut.Upgrade.Soe.Commands
             RouteNumber = routeNumber;
             LayerName = sgid10TransportationUdotroutesLrs;
             Workspace = workspace;
+            WhereClause = $"RT_NAME = '{RouteNumber.ToUpper()}' AND RT_DIR = '{Type}'";
         }
+
+        public FindRouteMilepostCommand(string route, string milePost, string sgid10TransportationUdotroutesLrs, IFeatureWorkspace workspace)
+        {
+            MilePost = milePost;
+            LayerName = sgid10TransportationUdotroutesLrs;
+            Workspace = workspace;
+            RouteNumber = route.ToUpper();
+            WhereClause = $"LABEL='{RouteNumber}'";
+            fullRoute = true;
+        }
+
+        private bool fullRoute;
 
         protected string MilePost { get; set; }
 
@@ -24,6 +37,8 @@ namespace Wsut.Upgrade.Soe.Commands
         protected string RouteNumber { get; set; }
 
         public string LayerName { get; set; }
+
+        private string WhereClause { get; }
 
         public IFeatureWorkspace Workspace { get; set; }
 
@@ -35,8 +50,7 @@ namespace Wsut.Upgrade.Soe.Commands
 
             var filter = new QueryFilter
                          {
-                             WhereClause =
-                                 string.Format("RT_NAME = '{0}' AND RT_DIR = '{1}'", RouteNumber.ToUpper(), Type)
+                             WhereClause = WhereClause
                          };
 
             var cursor = featureClass.Search(filter, false);
@@ -64,8 +78,8 @@ namespace Wsut.Upgrade.Soe.Commands
                     continue;
                 }
 
-                var result = new GeocodeResult(string.Format("Route {0}, Milepost {1}", RouteNumber, MilePost),
-                                           LayerName, 100)
+                var result = new GeocodeResult($"Route {RouteNumber}, Milepost {MilePost}",
+                                           LayerName, 100, fullRoute)
                 {
                     UTM_X = point.X,
                     UTM_Y = point.Y
@@ -77,9 +91,9 @@ namespace Wsut.Upgrade.Soe.Commands
                 result.LAT_Y = latLong[1];
 
                 Result = result;
-                
+
                 return;
-            }            
+            }
         }
 
         private static double[] ConvertUtmToLatLong(IPoint utmPoint)
@@ -97,8 +111,7 @@ namespace Wsut.Upgrade.Soe.Commands
 
         public override string ToString()
         {
-            return string.Format("{0}, MilePost: {1}, Type: {2}, RouteNumber: {3}", "FindRouteMilepostCommand", MilePost,
-                                 Type, RouteNumber);
+            return $"FindRouteMilepostCommand, MilePost: {MilePost}, Type: {Type}, RouteNumber: {RouteNumber}";
         }
     }
 }

--- a/WSUT.Upgrade.Soe/Models/GeocodeResult.cs
+++ b/WSUT.Upgrade.Soe/Models/GeocodeResult.cs
@@ -9,6 +9,7 @@ namespace WSUT.Upgrade.Soe.Models
     {
         private string _matchAddress;
         private double _longi, _lati;
+        private readonly bool _doNotFormat;
 
         [DataMember(Order = 1)]
         public string MatchAddress
@@ -16,9 +17,16 @@ namespace WSUT.Upgrade.Soe.Models
             get { return _matchAddress; }
             set
             {
-                var cultureInfo = Thread.CurrentThread.CurrentCulture;
-                var titleCaser = cultureInfo.TextInfo;
-                _matchAddress = titleCaser.ToTitleCase(value.ToLower());
+                if (_doNotFormat)
+                {
+                    _matchAddress = value.ToUpper();
+                }
+                else
+                {
+                    var cultureInfo = Thread.CurrentThread.CurrentCulture;
+                    var titleCaser = cultureInfo.TextInfo;
+                    _matchAddress = titleCaser.ToTitleCase(value.ToLower());
+                }
             }
         }
 
@@ -26,6 +34,7 @@ namespace WSUT.Upgrade.Soe.Models
         public string Geocoder;
         [DataMember(Order = 3)]
         public double Score;
+
         [DataMember(Order = 4)]
         public double UTM_X;
         [DataMember(Order = 5)]
@@ -46,8 +55,9 @@ namespace WSUT.Upgrade.Soe.Models
         public GeocodeResult()
         { }
 
-        public GeocodeResult(string matchAddress, string geocoder, double score)
+        public GeocodeResult(string matchAddress, string geocoder, double score, bool doNotFormat=false)
         {
+            _doNotFormat = doNotFormat;
             MatchAddress = matchAddress;
             Geocoder = geocoder;
             Score = score;

--- a/WSUT.Upgrade.Soe/Properties/AssemblyInfo.cs
+++ b/WSUT.Upgrade.Soe/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using ESRI.ArcGIS.SOESupport;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("WSUT.Upgrade.Soe")]
@@ -15,8 +15,8 @@ using ESRI.ArcGIS.SOESupport;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -26,15 +26,15 @@ using ESRI.ArcGIS.SOESupport;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]
 
 [assembly: AddInPackage("WSUT.Upgrade.Soe", "edae50b3-73f9-4a4a-bf8e-380360e41415",
     Author = "agrc-arcgis",

--- a/WebAPI.API/Commands/Geocode/MilePostCommand.cs
+++ b/WebAPI.API/Commands/Geocode/MilePostCommand.cs
@@ -39,7 +39,7 @@ namespace WebAPI.API.Commands.Geocode
 
         protected override void Execute()
         {
-            var requestUri = string.Format(Url, Route, Milepost, Options.Side);
+            var requestUri = string.Format(Url, Route, Milepost, Options.Side, Options.FullRoute);
 
             var response = App.HttpClient.GetAsync(requestUri).ContinueWith(
                 httpResponse => ConvertResponseToObjectAsync(httpResponse.Result)).Unwrap().Result;

--- a/WebAPI.API/Commands/Geocode/StandardizeRouteNameCommand.cs
+++ b/WebAPI.API/Commands/Geocode/StandardizeRouteNameCommand.cs
@@ -14,7 +14,7 @@ namespace WebAPI.API.Commands.Geocode
 
         public override string ToString()
         {
-            return string.Format("{0}, Route: {1}", "StandardizeRouteNameCommand", Route);
+            return $"StandardizeRouteNameCommand, Route: {Route}";
         }
 
         protected override void Execute()

--- a/WebAPI.API/Controllers/API/Version1/GeocodeController.cs
+++ b/WebAPI.API/Controllers/API/Version1/GeocodeController.cs
@@ -312,7 +312,11 @@ namespace WebAPI.API.Controllers.API.Version1
 
             var errors = "";
 
-            var standardRoute = CommandExecutor.ExecuteCommand(new StandardizeRouteNameCommand(route));
+            var standardRoute = route;
+            if (!options.FullRoute)
+            {
+                standardRoute = CommandExecutor.ExecuteCommand(new StandardizeRouteNameCommand(route));
+            }
 
             if (string.IsNullOrEmpty(route) || string.IsNullOrEmpty(standardRoute))
             {
@@ -321,7 +325,7 @@ namespace WebAPI.API.Controllers.API.Version1
 
             if (string.IsNullOrEmpty(milepost) || !double.TryParse(milepost, out milepostNumber))
             {
-                errors += "milepost is emtpy or in unexpected format. Expected number eg: 300, 300.009";
+                errors += "milepost is empty or in unexpected format. Expected number eg: 300, 300.009";
             }
 
             if (errors.Length > 0)

--- a/WebAPI.API/ModelBindings/RouteMilepostOptionsModelBinding.cs
+++ b/WebAPI.API/ModelBindings/RouteMilepostOptionsModelBinding.cs
@@ -15,9 +15,12 @@ namespace WebAPI.API.ModelBindings
 
             string side = keyValueModel["side"],
                    format = keyValueModel["format"],
-                   spatialReference = keyValueModel["spatialReference"];
+                   spatialReference = keyValueModel["spatialReference"],
+                   fullRoute = keyValueModel["fullRoute"];
 
             var jsonFormat = JsonFormat.None;
+
+            bool.TryParse(string.IsNullOrEmpty(fullRoute) ? "false" : fullRoute, out var usingFullRouteName);
 
             int wkid;
 
@@ -44,8 +47,9 @@ namespace WebAPI.API.ModelBindings
                 {
                     Side = sideType,
                     JsonFormat = jsonFormat,
-                    WkId = wkid
-                };
+                    WkId = wkid,
+                    FullRoute = usingFullRouteName
+            };
 
             return true;
         }

--- a/WebAPI.API/Views/Geocode/_MilePost.cshtml
+++ b/WebAPI.API/Views/Geocode/_MilePost.cshtml
@@ -1,6 +1,8 @@
 ﻿<div class="well">
-    <span class="label label-verb label-get pull-left">Get</span> <span class="label label-url url pull-right">
-                                                                      /geocode/milepost/:route/:milepost</span>
+    <span class="label label-verb label-get pull-left">Get</span>
+    <span class="label label-url url pull-right">
+        /geocode/milepost/:route/:milepost
+    </span>
     <div class="clearfix">
     </div>
     <h3>
@@ -24,8 +26,10 @@
                 </label>
                 <div class="col-sm-8">
                     <input type="text" id="route" name="route" class="form-control" data-required/>
-                    <span class="help-inline label label-info">number</span> <span class="help-inline label label-danger">
-                                                                                 required</span>
+                    <span class="help-inline label label-info">number</span>
+                    <span class="help-inline label label-danger">
+                        required
+                    </span>
                     <p class="help-block">
                         The Utah highway number. eg: <code>15</code>.
                     </p>
@@ -37,8 +41,10 @@
                 </label>
                 <div class="col-sm-8">
                     <input type="text" id="milepost" name="milepost" class="form-control" data-required/>
-                    <span class="help-inline label label-info">number</span> <span class="help-inline label label-danger">
-                                                                                 required</span>
+                    <span class="help-inline label label-info">number</span>
+                    <span class="help-inline label label-danger">
+                        required
+                    </span>
                     <p class="help-block">
                         The highway milepost. eg: <code>309.001</code>. Milepost precision is up to 1/1000 of a mile (approximately 5 feet).
                     </p>
@@ -54,8 +60,10 @@
                         <option value="increasing">increasing</option>
                         <option value="decreasing">decreasing</option>
                     </select>
-                    <span class="help-inline label label-info">string</span> <span class="help-inline label label-success">
-                                                                                 optional</span>
+                    <span class="help-inline label label-info">string</span>
+                    <span class="help-inline label label-success">
+                        optional
+                    </span>
                     <p class="help-block">
                         <span class="label label-warning">For divided highways only.</span>. The side of the divided highway to match. <code>Increasing</code> if you are on the positive side of the divided highway (The mileposts are getting larger as you drive). <code>Decreasing</code> if you are on the negative side of a divided highway (the mileposts are getting smaller as you drive). Default is <code>Increasing</code>.
                     </p>
@@ -67,8 +75,10 @@
                 </label>
                 <div class="col-sm-8">
                     <input type="text" id="spatialReference" name="spatialReference" class="form-control"/>
-                    <span class="help-inline label label-info">string</span> <span class="help-inline label label-success">
-                                                                                 optional</span>
+                    <span class="help-inline label label-info">string</span>
+                    <span class="help-inline label label-success">
+                        optional
+                    </span>
                     <p class="help-block">
                         The spatial reference for the output and input geometries.
                         <strong class="text-warning">The output and input spatial references must match.</strong>
@@ -80,15 +90,36 @@
                     @Html.Partial("_SpatialReference")
                 </div>
             </div>
-
+            <div class="form-group">
+                <label class="col-sm-2 control-label" for="fullRoute">
+                    fullRoute
+                </label>
+                <div class="col-sm-8">
+                    <select id="fullRoute" name="fullRoute" class="form-control">
+                        <option value>fullRoute
+                        <option value="true">True
+                        <option value="false">False
+                    </select>
+                    <span class="help-inline label label-info">boolean</span>
+                    <span class="help-inline label label-success">
+                        optional
+                    </span>
+                    <p class="help-block">
+                        Search using the full route name as it is in the source data (e.g., <code>0015PC30554</code>).
+                        <span class="text-warning"><code>route</code> changes from a number to a string. <code>side</code> is ignored as it becomes a part of the <code>route</code></span>. <code>False</code> is the default.
+                    </p>
+                </div>
+            </div>
             <div class="form-group">
                 <label class="col-sm-2 control-label" for="callback">
                     callback
                 </label>
                 <div class="col-sm-8">
                     <input type="text" id="callback" name="callback" class="form-control"/>
-                    <span class="help-inline label label-info">string</span> <span class="help-inline label label-success">
-                                                                                 optional</span>
+                    <span class="help-inline label label-info">string</span>
+                    <span class="help-inline label label-success">
+                        optional
+                    </span>
                     <p class="help-block">
                         The callback function to call for cross domain javascript calls (jsonp).
                     </p>
@@ -104,8 +135,10 @@
                         <option value="esrijson">esrijson</option>
                         <option value="geojson">geojson</option>
                     </select>
-                    <span class="help-inline label label-info">string</span> <span class="help-inline label label-success">
-                                                                                 optional</span>
+                    <span class="help-inline label label-info">string</span>
+                    <span class="help-inline label label-success">
+                        optional
+                    </span>
                     <p class="help-block">
                         The format of the resulting milepost. esri json will easily parse into an esri.Graphic
                         for display on a map and geojson will easily parse into a feature for use in many

--- a/WebAPI.API/secrets.template.config
+++ b/WebAPI.API/secrets.template.config
@@ -7,7 +7,7 @@
   <add key="sgid_connection" value="Data Source="/>
 
   <add key="geometry_service_url" value="http://localhost/arcgis/rest/services/Geometry/GeometryServer/project?f=json&amp;{0}" />
-  <add key="milepost_url" value="http://localhost/arcgis/rest/services/Soe/WSUTUpgrade/MapServer/exts/WsutUpgradeSoe/RouteMilePost?routeNumber={0}&amp;milepost={1}&amp;routeType={2}&amp;f=json" />
+  <add key="milepost_url" value="http://localhost/arcgis/rest/services/Soe/WSUTUpgrade/MapServer/exts/WsutUpgradeSoe/RouteMilePost?routeNumber={0}&amp;fullRoute={3}&amp;milepost={1}&amp;routeType={2}&amp;f=json" />
   <add key="reverse_milepost_url" value="http://localhost/arcgis/rest/services/Soe/SearchApi/MapServer/exts/Search/ReverseMilepost?{0}&amp;f=json" />
   <add key="search_url" value="http://localhost/arcgis/rest/services/Soe/SearchApi/MapServer/exts/Search/Search?{0}&amp;f=json" />
 </appSettings>

--- a/WebAPI.Domain/InputOptions/MilePostOptions.cs
+++ b/WebAPI.Domain/InputOptions/MilePostOptions.cs
@@ -29,9 +29,14 @@ namespace WebAPI.Domain.InputOptions
         /// </value>
         public int WkId { get; set; }
 
+        /// <summary>
+        ///  Decides whether the route is the highway only or the highway + direction + milepost from the data
+        /// </summary>
+        public bool FullRoute { get; set; }
+
         public override string ToString()
         {
-            return string.Format("Side: {0}", Side);
+            return $"Side: {Side}. Use FullRoute {FullRoute}";
         }
     }
 }


### PR DESCRIPTION
a query with `route:0015PC30554`, `milepost:1.1`, and `fullRoute:true` will use the `LABEL` field in the `UDOT_LRS` data to find the correct segment.

@clancyblack does this look like it will do as you wanted with #83?