### PR TITLE
Dev feature/encode address strings

### DIFF
--- a/src/explorer/src/components/Endpoint/Documentation/Elements.js
+++ b/src/explorer/src/components/Endpoint/Documentation/Elements.js
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 
 function Tip(props) {
   return (
-    <div>
+    <div className={props.className}>
       <div className="p-2 bg-gray-600 text-indigo-100 leading-none flex" role="alert">
         <span className="flex self-start md:self-center rounded-full bg-gray-900 uppercase px-2 py-1 text-xs font-bold mr-3">Tip</span>
         <span className="mr-2 text-left flex-auto font-md leading-5">{props.children}</span>

--- a/src/explorer/src/components/Endpoint/Endpoint.js
+++ b/src/explorer/src/components/Endpoint/Endpoint.js
@@ -3,6 +3,7 @@ import EndpointDemoDocToggle from './EndpointDemoDocToggle';
 import EndpointResponse from './EndpointResponse';
 import EndpointUrl from './EndpointUrl';
 import Button from '../Button';
+import { Tip } from '../Endpoint/Documentation/Elements';
 
 const getComponent = (key, children) => {
   return children.filter(comp => {
@@ -88,6 +89,10 @@ export default function Endpoint(props) {
           {api ? (
             <div className="flex flex-col justify-center w-full py-3">
               <EndpointUrl url={props.displayUrl}></EndpointUrl>
+              {props.invalidCharacter ?
+                <Tip className="mt-3">
+                  Just a heads up! We have automatically encoded "{props.invalidCharacter}" in your street value. You'll want to do this in your code.
+                </Tip> : null}
               {response ? <EndpointResponse {...response}></EndpointResponse> : null}
               <Button type="submit" disabled={!props.fetchUrl || props.fetchUrl.length < 1} className="justify-center w-1/2 self-center my-5 font-medium">
                 Send it

--- a/src/explorer/src/components/Endpoint/Endpoint.js
+++ b/src/explorer/src/components/Endpoint/Endpoint.js
@@ -91,7 +91,7 @@ export default function Endpoint(props) {
               <EndpointUrl url={props.displayUrl}></EndpointUrl>
               {props.invalidCharacter ?
                 <Tip className="mt-3">
-                  Just a heads up! We have automatically encoded "{props.invalidCharacter}" in your street value. You'll want to do this in your code.
+                  We have detected a reserved url character in your street input and have url encoded the `{props.invalidCharacter}`. Url encoding will need to be handled with your implementation or unexpected results will occur.
                 </Tip> : null}
               {response ? <EndpointResponse {...response}></EndpointResponse> : null}
               <Button type="submit" disabled={!props.fetchUrl || props.fetchUrl.length < 1} className="justify-center w-1/2 self-center my-5 font-medium">

--- a/src/explorer/src/components/Endpoint/Endpoint.js
+++ b/src/explorer/src/components/Endpoint/Endpoint.js
@@ -21,14 +21,18 @@ export default function Endpoint(props) {
       return;
     }
 
-    const response = await fetch(url, {
-      method: 'GET',
-      mode: 'cors'
-    });
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        mode: 'cors'
+      });
 
-    const result = await response.json();
+      const result = await response.json();
 
-    setResponse(JSON.stringify(result, null, 2));
+      setResponse({ success: true, code: JSON.stringify(result, null, 2) });
+    } catch (error) {
+      setResponse({ success: false, code: error.message });
+    }
   };
 
   const [collapsed, setCollapsed] = useState(defaultValue);
@@ -84,7 +88,7 @@ export default function Endpoint(props) {
           {api ? (
             <div className="flex flex-col justify-center w-full py-3">
               <EndpointUrl url={props.displayUrl}></EndpointUrl>
-              {response ? <EndpointResponse code={response}></EndpointResponse> : null}
+              {response ? <EndpointResponse {...response}></EndpointResponse> : null}
               <Button type="submit" disabled={!props.fetchUrl || props.fetchUrl.length < 1} className="justify-center w-1/2 self-center my-5 font-medium">
                 Send it
               </Button>

--- a/src/explorer/src/components/Endpoint/EndpointResponse.js
+++ b/src/explorer/src/components/Endpoint/EndpointResponse.js
@@ -11,7 +11,7 @@ export default function Code({ success, code }) {
   const classes = classNames({
     'border-indigo-300': success,
     'border-red-300': !success
-  }, 'max-w-3/4 break-all flex self-center mt-5 rounded border text-sm');
+  }, 'break-all flex self-center mt-5 rounded border text-sm');
 
   return (
     <SyntaxHighlighter

--- a/src/explorer/src/components/Endpoint/EndpointResponse.js
+++ b/src/explorer/src/components/Endpoint/EndpointResponse.js
@@ -3,17 +3,23 @@ import React from 'react';
 import SyntaxHighlighter from 'react-syntax-highlighter/dist/esm/light-async'
 import json from 'react-syntax-highlighter/dist/esm/languages/hljs/javascript';
 import theme from 'react-syntax-highlighter/dist/esm/styles/hljs/mono-blue';
+import classNames from 'classnames';
 
 SyntaxHighlighter.registerLanguage('json', json);
 
-export default function Code(props) {
+export default function Code({ success, code }) {
+  const classes = classNames({
+    'border-indigo-300': success,
+    'border-red-300': !success
+  }, 'max-w-3/4 break-all flex self-center mt-5 rounded border text-sm');
+
   return (
     <SyntaxHighlighter
-      className="max-w-3/4 break-all flex self-center mt-5 rounded border border-indigo-300 text-sm"
+      className={classes}
       language="json"
       style={theme}
       wrapLines={false}>
-      {props.code}
+      {code}
     </SyntaxHighlighter>
   );
 }

--- a/src/explorer/src/components/Endpoint/EndpointUrl.js
+++ b/src/explorer/src/components/Endpoint/EndpointUrl.js
@@ -4,7 +4,7 @@ import CopyText from '@gradeup/copy-text-to-cb';
 export default function Url(props) {
   return props.url ? (
     <div className="flex justify-center">
-      <span className="max-w-3/4 break-all flex self-center p-2 text-base leading-6 text-gray-700 rounded-l border border-r-0 border-indigo-300 bg-gray-200">
+      <span className="break-all flex self-center p-2 text-base leading-6 text-gray-700 rounded-l border border-r-0 border-indigo-300 bg-gray-200">
         {props.url}
       </span>
       <CopyText

--- a/src/explorer/src/components/Endpoint/Geocoding/StreetZone/StreetZoneApi.js
+++ b/src/explorer/src/components/Endpoint/Geocoding/StreetZone/StreetZoneApi.js
@@ -9,6 +9,7 @@ import schema from './meta';
 
 const url = 'https://api.mapserv.utah.gov/api/v1/geocode/:street/:zone';
 const initialState = schema.getDefault();
+const charactersToWarnOn = ['#', '?', '&'];
 
 const reducer = produce((draft, action) => {
   draft[action.type] = action.payload;
@@ -18,7 +19,7 @@ const reducer = produce((draft, action) => {
 
 export default function StreetZone(props) {
   const [state, dispatch] = useReducer(reducer, initialState);
-  const { setFetchUrl, setDisplayUrl } = props.urls;
+  const { setFetchUrl, setDisplayUrl, setInvalidCharacter } = props.urls;
 
   useEffect(() => {
     if (!hasRequiredParts(state, url, initialState)) {
@@ -28,9 +29,18 @@ export default function StreetZone(props) {
       return;
     }
 
+    let specialCharacter;
+    charactersToWarnOn.forEach(character => {
+      if (state.street.includes(character)) {
+        specialCharacter = character;
+      }
+    });
+
+    setInvalidCharacter(specialCharacter);
+
     setDisplayUrl(stringify(state, url, initialState, 'your-api-key'));
     setFetchUrl(stringify(state, url, initialState, process.env.REACT_APP_API_KEY));
-  }, [state, setFetchUrl, setDisplayUrl]);
+  }, [state, setFetchUrl, setDisplayUrl, setInvalidCharacter]);
 
   return (
     <>

--- a/src/explorer/src/components/Endpoint/Geocoding/StreetZone/StreetZoneEndpoint.js
+++ b/src/explorer/src/components/Endpoint/Geocoding/StreetZone/StreetZoneEndpoint.js
@@ -11,10 +11,15 @@ const meta = {
 export default function StreetZone(props) {
   const [fetchUrl, setFetchUrl] = useState('');
   const [displayUrl, setDisplayUrl] = useState('');
+  const [invalidCharacter, setInvalidCharacter] = useState();
 
   return (
-    <Endpoint {...meta} displayUrl={displayUrl} fetchUrl={fetchUrl} collapsed={props.collapsed}>
-      <StreetZoneApi urls={{ setFetchUrl, setDisplayUrl }} key="api"></StreetZoneApi>
+    <Endpoint {...meta}
+      displayUrl={displayUrl}
+      fetchUrl={fetchUrl}
+      collapsed={props.collapsed}
+      invalidCharacter={invalidCharacter}>
+      <StreetZoneApi urls={{ setFetchUrl, setDisplayUrl, setInvalidCharacter }} key="api"></StreetZoneApi>
       <StreetZoneDocs key="docs"></StreetZoneDocs>
     </Endpoint>
   );

--- a/src/explorer/src/components/Endpoint/QueryString.js
+++ b/src/explorer/src/components/Endpoint/QueryString.js
@@ -8,7 +8,7 @@ export default function stringify(values, url, initial, apiKey) {
 
   // replace required parts
   requiredParts.forEach(part => {
-    url = url.replace(`:${part}`, values[part]);
+    url = url.replace(`:${part}`, encodeURIComponent(values[part]));
     delete values[part];
   });
 


### PR DESCRIPTION
This is an attempt to address #120 for v2. I've got the encoding working for the required parameters. `querystring` was already handling it for the optional params although I don't think that this issue applies to those.

The only question that I have is under what circumstances do we want to display a warning message about encoding? Spaces are technically encoded, but that would mean we display a message on every request. Do we want to search for a certain set of characters such as `#` and only display a message when those are found?