### PR TITLE
feat(explorer): add api version url parameter to documentation route

### DIFF
--- a/src/explorer/src/App.js
+++ b/src/explorer/src/App.js
@@ -4,8 +4,11 @@ import { ResponsiveSideNav, FixedBottomNav, InlineTopNav, CommonLinks } from './
 import { Landing, SellIt, Whats, Goals } from './components/Home';
 import GettingStarted from './components/GettingStarted';
 import { StreetZoneEndpoint } from './components/Endpoint/Geocoding';
-import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Switch, Route, Redirect } from 'react-router-dom';
 import PrivacyPolicy from './components/PrivacyPolicy';
+
+const DOCUMENTATION_PATH = 'documentation';
+const DEFAULT_API_VERSION = 'v2';
 
 export default function App() {
   return (
@@ -42,7 +45,10 @@ export default function App() {
           </InlineTopNav>
           <GettingStarted></GettingStarted>
         </Route>
-        <Route exact path="/documentation">
+        <Route exact path={`/${DOCUMENTATION_PATH}`}>
+          <Redirect to={`/${DOCUMENTATION_PATH}/${DEFAULT_API_VERSION}`} />
+        </Route>
+        <Route exact path={`/${DOCUMENTATION_PATH}/:apiVersion`}>
           <InlineTopNav>
             <CommonLinks></CommonLinks>
           </InlineTopNav>

--- a/src/explorer/src/components/Endpoint/Geocoding/StreetZone/StreetZoneEndpoint.js
+++ b/src/explorer/src/components/Endpoint/Geocoding/StreetZone/StreetZoneEndpoint.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import Endpoint from '../../Endpoint';
 import StreetZoneApi from './StreetZoneApi';
 import StreetZoneDocs from './StreetZoneDocs';
+import { useParams } from 'react-router-dom';
 
 const meta = {
   description: 'Finding a spatial coordinate on the ground for an address',
@@ -9,6 +10,9 @@ const meta = {
 };
 
 export default function StreetZone(props) {
+  const { apiVersion } = useParams();
+  console.log(`api version: ${apiVersion}`);
+
   const [fetchUrl, setFetchUrl] = useState('');
   const [displayUrl, setDisplayUrl] = useState('');
 


### PR DESCRIPTION
This is one way of supporting a version URL param. I _think_ that I like it the best out of the few that I tried. You should be able to use the `useParams` hook in any child component.

Closes #121