### PR TITLE
add: bryce placename mapping

### DIFF
--- a/WebAPI.API/Commands/Drive/GetStaticDriveCommand.cs
+++ b/WebAPI.API/Commands/Drive/GetStaticDriveCommand.cs
@@ -433,6 +433,7 @@ namespace WebAPI.API.Commands.Drive
                 new [] { "BRYCE CYN CNTY", "BRYCE CANYON COUNTY", "3"},
                 new [] { "BRYCE CYN COUNTY", "BRYCE CANYON COUNTY", "4"},
                 new [] { "BRYCE", "BRYCE CANYON CITY", "3"},
+                new [] { "BRYCE", "BRYCE CANYON COUNTY", "2"},
                 new [] { "BULLFROG", "BULLFROG", "0"},
                 new [] { "BURBANK", "DELTA", "0"},
                 new [] { "BURMESTER", "TOOELE", "0"},


### PR DESCRIPTION
Map an alternate for 'Bryce' to the 'Bryce Canyon County' grid