### PR TITLE
feat: add mammoth grid

### DIFF
--- a/WebAPI.API/Commands/Drive/GetStaticDriveCommand.cs
+++ b/WebAPI.API/Commands/Drive/GetStaticDriveCommand.cs
@@ -783,6 +783,7 @@ namespace WebAPI.API.Commands.Drive
                 new [] { "MAMMOTH CREEK", "MAMMOTH CREEK", "1"},
                 new [] { "MAMMOTH CRK", "MAMMOTH CREEK", "0"},
                 new [] { "MAMMOTH", "EUREKA", "0"},
+                new [] { "MAMMOTH", "MAMMOTH", "1"},
                 new [] { "MANDERFIELD", "BEAVER", "0"},
                 new [] { "MANDERFIELD", "MANDERFIELD", "1"},
                 new [] { "MANILA", "MANILA", "0"},


### PR DESCRIPTION
Creating a PR to add the Mammoth address grid.  This will prevent conflicts with Eureka (were Mammoth was previously mapped to) and allow for better geocodes in Mammoth, particularly on Main St, which had range overlaps in Eureka.  The polygons and address points will be update in internal on 4/4/2023, roads should be update by @gregbunce on 4/5/2023.

Eureka will now be the fall-back/second option for Mammoth.