### PR TITLE
ci: add cooldown settings to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,24 +10,40 @@ updates:
       interval: monthly
     groups:
       safe-dependencies:
-        update-types: ['minor', 'patch']
+        update-types:
+          - minor
+          - patch
       major-dependencies:
-        update-types: ['major']
+        update-types:
+          - major
     commit-message:
       prefix: deps
       prefix-development: deps(dev)
+    cooldown:
+      default-days: 10
+      semver-major-days: 60
+      semver-minor-days: 14
+      semver-patch-days: 7
   - package-ecosystem: pip
     directory: /forklift
     schedule:
       interval: monthly
     groups:
       safe-dependencies:
-        update-types: ['minor', 'patch']
+        update-types:
+          - minor
+          - patch
       major-dependencies:
-        update-types: ['major']
+        update-types:
+          - major
     commit-message:
       prefix: deps
       prefix-development: deps(dev)
+    cooldown:
+      default-days: 10
+      semver-major-days: 60
+      semver-minor-days: 14
+      semver-patch-days: 7
   - package-ecosystem: npm
     directories:
       - src/developer
@@ -36,16 +52,26 @@ updates:
       interval: monthly
     groups:
       safe-dependencies:
-        update-types: ['minor', 'patch']
+        update-types:
+          - minor
+          - patch
       major-dependencies:
-        update-types: ['major']
+        update-types:
+          - major
     commit-message:
       prefix: deps
       prefix-development: deps(dev)
+    cooldown:
+      default-days: 10
+      semver-major-days: 60
+      semver-minor-days: 14
+      semver-patch-days: 7
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
     groups:
       ci-dependencies:
-        dependency-type: 'production'
+        dependency-type: production
+    cooldown:
+      default-days: 10


### PR DESCRIPTION
This PR adds [cooldown settings](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-) to the dependabot configuration for all package ecosystems.

## What this does:

- Allows dependabot to delay including dependencies for a configurable number of days.

## Benefits:

- The community finds supply chain vulnerabilities and bugs before they are included in a pull request.
