### PR TITLE
fix: remove offer to create dedicated api instances

### DIFF
--- a/src/developer/src/components/page/SelfService.jsx
+++ b/src/developer/src/components/page/SelfService.jsx
@@ -111,8 +111,7 @@ export function Component() {
           <h3 className="text-center dark:text-slate-200">Fair use disclaimer</h3>
           <p className="dark:text-slate-200">
             This API is free to use and we ask that you use it responsibly and fairly. We reserve the right to block
-            abusive users. Currently, the API is not rate limited so please be courteous to other users. If you need
-            more bandwidth than we are able to provide, we can set up a dedicated instance for you.
+            abusive users. Currently, the API is not rate limited so please be courteous to other users.
           </p>
         </div>
       </section>

--- a/src/explorer/src/pages/getting-started.astro
+++ b/src/explorer/src/pages/getting-started.astro
@@ -133,16 +133,8 @@ import { SELF_SERVICE_URL } from 'astro:env/client';
         <span class="mr-2 flex-auto text-left font-semibold"
           >This API is free to use and we ask that you use it responsibly and
           fairly. We reserve the right to block abusive users. Currently, the
-          API is not rate limited so please be courteous to other users. If you
-          need more bandwidth than we are able to provide, a dedicated instance
-          can be setup for you. Contact us by email at <a
-            href="mailto:ugrc-developers@utah.gov"
-            class="">ugrc-developers@utah.gov</a
-          > or by <a
-            href="https://github.com/agrc/api.mapserv.utah.gov/issues/new"
-            class="">opening an issue on GitHub</a
-          >.</span
-        >
+          API is not rate limited so please be courteous to other users.
+        </span>
       </div>
     </div>
     <section class="border-b border-slate-400 p-6">


### PR DESCRIPTION
This was done once and was questionable in terms of arcgis server licenses.