### PR TITLE
fix(api): keep esrijson attribute keys camel cased

### DIFF
--- a/src/api/Features/Geocoding/SingleGeocodeResponseContract.cs
+++ b/src/api/Features/Geocoding/SingleGeocodeResponseContract.cs
@@ -103,7 +103,7 @@ public class SingleGeocodeResponseContract : Suggestable, IConvertible<SingleGeo
                         value = wkid;
                     }
 
-                    attributes.Add(property.Name, value);
+                    attributes.Add(property.Name.ToCamelCase(), value);
                 }
             } else {
                 attributes = properties

--- a/test/api.unit.tests/Features/Geocoding/SingleGeocodeResponseContractTests.cs
+++ b/test/api.unit.tests/Features/Geocoding/SingleGeocodeResponseContractTests.cs
@@ -72,16 +72,16 @@ public class SingleGeocodeResponseContractTests {
                 point.Y.ShouldBe(2);
             }
 
-            feature.Attributes.Keys.ToList().ShouldBe(["Location", "Score", "Locator", "MatchAddress", "InputAddress", "StandardizedAddress", "AddressGrid", "ScoreDifference", "Wkid", "Candidates"]);
-            feature.Attributes["Location"].ShouldNotBeNull();
-            feature.Attributes["Score"].ShouldBe(score);
-            feature.Attributes["Locator"].ShouldBe(locatorType.ToString());
-            feature.Attributes["MatchAddress"].ShouldBe("Test Address");
-            feature.Attributes["InputAddress"].ShouldBe("Test Address");
-            feature.Attributes["AddressGrid"].ShouldBe("Grid");
-            feature.Attributes["ScoreDifference"].ShouldBe(2);
-            feature.Attributes["Wkid"].ShouldBe(wkid);
-            feature.Attributes["Candidates"].ShouldBeNull();
+            feature.Attributes.Keys.ToList().ShouldBe(["location", "score", "locator", "matchAddress", "inputAddress", "standardizedAddress", "addressGrid", "scoreDifference", "wkid", "candidates"]);
+            feature.Attributes["location"].ShouldNotBeNull();
+            feature.Attributes["score"].ShouldBe(score);
+            feature.Attributes["locator"].ShouldBe(locatorType.ToString());
+            feature.Attributes["matchAddress"].ShouldBe("Test Address");
+            feature.Attributes["inputAddress"].ShouldBe("Test Address");
+            feature.Attributes["addressGrid"].ShouldBe("Grid");
+            feature.Attributes["scoreDifference"].ShouldBe(2);
+            feature.Attributes["wkid"].ShouldBe(wkid);
+            feature.Attributes["candidates"].ShouldBeNull();
         }
     }
     [Fact]


### PR DESCRIPTION
This keeps `format=esrijson` attribute keys camel cased for v1 geocode responses so they match the default JSON response shape.

- convert reflected property names to camel case in `SingleGeocodeResponseContract.ToEsriJson`
- update unit expectations in `SingleGeocodeResponseContractTests`

Fixes #722.